### PR TITLE
[Bug] fixed #60 - Removed unneeded contollers folder

### DIFF
--- a/client/app/contollers/AuthCtrl.js
+++ b/client/app/contollers/AuthCtrl.js
@@ -1,5 +1,0 @@
-angular.module('followApp')
-
-.controller('AuthCtrl', ['$scope', function($scope) {
-  
-}]);

--- a/client/app/contollers/ContactsCtrl.js
+++ b/client/app/contollers/ContactsCtrl.js
@@ -1,5 +1,0 @@
-angular.module('followApp')
-
-.controller('ContactsCtrl', ['$scope', function($scope) {
-  
-}]);

--- a/client/app/contollers/ConversationsCtrl.js
+++ b/client/app/contollers/ConversationsCtrl.js
@@ -1,5 +1,0 @@
-angular.module('followApp')
-
-.controller('ConversationsCtrl', ['$scope', function($scope) {
-  
-}]);


### PR DESCRIPTION
We had originally misspelled the controllers folder as contoller, so when we made the move to rename it correctly, we accidentally keep the other misspelled folder as well.
